### PR TITLE
simplify AI engine

### DIFF
--- a/src/ai-engine.ts
+++ b/src/ai-engine.ts
@@ -22,125 +22,101 @@ export interface AIAnnotationResponse {
     }[];
 }
 
-// --- The Standard Interface ---
+// --- Gemini Annotation Helper ---
 
-export interface AIEngine {
-    /**
-     *
-     * Takes an image and a prompt, and returns structured annotation data.
-     *
-     * This method can implement various strategies, like multi-round refinement.
-     */
-    annotate(request: AIAnnotationRequest): Promise<AIAnnotationResponse>;
+/**
+ * Annotate a page image using the Gemini API.
+ */
+export async function annotateWithGemini(
+    apiKey: string,
+    request: AIAnnotationRequest,
+    model = 'gemini-2.5-pro'
+): Promise<AIAnnotationResponse> {
+    console.log('Gemini Engine: Starting 1-round annotation process.');
+
+    const round1ResponseText = await runRound1(apiKey, model, request);
+    const finalAnnotations = parseAIResponse(round1ResponseText);
+
+    console.log(`Gemini Engine: Completed. Found ${finalAnnotations.length} annotations.`);
+
+    return {
+        rawResponse: round1ResponseText,
+        parsedAnnotations: finalAnnotations,
+    };
 }
 
-// --- A Specific Implementation for Google Gemini ---
+async function runRound1(apiKey: string, model: string, request: AIAnnotationRequest): Promise<string> {
+    console.log('Gemini Engine: Round 1 - Generating initial annotations.');
+    const imageParts: any[] = [{ text: request.prompt }];
 
-export class GeminiEngine implements AIEngine {
-    private apiKey: string;
-    private model: string;
+    // Add the main image to be annotated
+    imageParts.push({ inline_data: { mime_type: 'image/png', data: request.base64Image } });
 
-    constructor(apiKey: string, model = 'gemini-2.5-pro') {
-        this.apiKey = apiKey;
-        this.model = model;
-    }
+    if (request.examples && request.examples.length > 0) {
+        let exampleText = `\n\nI'm providing ${request.examples.length} example(s) from OTHER pages to show the desired style. Use them as a guide for the quality and detail expected. DO NOT copy these annotations; create new ones for the image provided above.\n`;
 
-    public async annotate(request: AIAnnotationRequest): Promise<AIAnnotationResponse> {
-        // This implementation uses a single-round annotation process.
-        console.log("Gemini Engine: Starting 1-round annotation process.");
-
-        // Round 1: Initial annotation generation.
-        const round1ResponseText = await this.runRound1(request);
-        const finalAnnotations = this.parseAIResponse(round1ResponseText);
-
-        console.log(`Gemini Engine: Completed. Found ${finalAnnotations.length} annotations.`);
-
-        return {
-            rawResponse: round1ResponseText,
-            parsedAnnotations: finalAnnotations,
-        };
-    }
-
-    private async runRound1(request: AIAnnotationRequest): Promise<string> {
-        console.log("Gemini Engine: Round 1 - Generating initial annotations.");
-        let prompt = request.prompt;
-
-        const imageParts: any[] = [{ text: prompt }];
-
-        // Add the main image to be annotated
-        imageParts.push({
-            inline_data: { mime_type: "image/png", data: request.base64Image }
-        });
-
-        // Add few-shot examples if they exist
-        if (request.examples && request.examples.length > 0) {
-            let exampleText = `\n\nI'm providing ${request.examples.length} example(s) from OTHER pages to show the desired style. Use them as a guide for the quality and detail expected. DO NOT copy these annotations; create new ones for the image provided above.\n`;
-            
-            for (const example of request.examples) {
-                exampleText += `\n--- Example ---\nAnnotations (JSON):\n${JSON.stringify(example.annotations, null, 2)}\n\nVisual (see image below):\n`;
-                imageParts.push({
-                    inline_data: { mime_type: "image/png", data: example.base64Image }
-                });
-            }
-            imageParts[0] = { text: prompt + exampleText };
+        for (const example of request.examples) {
+            exampleText += `\n--- Example ---\nAnnotations (JSON):\n${JSON.stringify(example.annotations, null, 2)}\n\nVisual (see image below):\n`;
+            imageParts.push({ inline_data: { mime_type: 'image/png', data: example.base64Image } });
         }
-
-        return this.callApi(imageParts);
+        imageParts[0] = { text: request.prompt + exampleText };
     }
 
-    private async callApi(parts: any[]): Promise<string> {
-        const requestBody = {
-            contents: [{ parts }],
-            generationConfig: {
-                temperature: 0.1,
-                maxOutputTokens: 262144, // 256k tokens for complex documents with many regions
-                response_mime_type: "application/json",
-            }
-        };
+    return callApi(apiKey, model, imageParts);
+}
 
-        const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`, {
+async function callApi(apiKey: string, model: string, parts: any[]): Promise<string> {
+    const requestBody = {
+        contents: [{ parts }],
+        generationConfig: {
+            temperature: 0.1,
+            maxOutputTokens: 262144,
+            response_mime_type: 'application/json',
+        },
+    };
+
+    const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`,
+        {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(requestBody)
-        });
-
-        if (!response.ok) {
-            const errorData = await response.text();
-            console.error("Gemini API Error:", errorData);
-            throw new Error(`Gemini API error: ${response.status} - ${errorData}`);
+            body: JSON.stringify(requestBody),
         }
+    );
 
-        const data = await response.json();
-        const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
-        if (!text) {
-            console.error("Invalid response from Gemini API:", data);
-            throw new Error('Invalid response from Gemini API');
-        }
-        return text;
+    if (!response.ok) {
+        const errorData = await response.text();
+        console.error('Gemini API Error:', errorData);
+        throw new Error(`Gemini API error: ${response.status} - ${errorData}`);
     }
 
-    private parseAIResponse(responseText: string): any[] {
-        try {
-            // The API is now requested to return JSON directly.
-            const parsed = JSON.parse(responseText);
-            if (!Array.isArray(parsed)) {
-                throw new Error('AI response is not a JSON array.');
-            }
-            // TODO: Add validation for each object in the array.
-            return parsed;
-        } catch (error) {
-            console.error('Failed to parse AI JSON response:', error);
-            console.log('Raw AI response:', responseText);
-            // As a fallback, try to extract from markdown code block
-            const jsonMatch = responseText.match(/```json\n([\s\S]*?)\n```/);
-            if (jsonMatch) {
-                try {
-                    return JSON.parse(jsonMatch[1]);
-                } catch (e) {
-                    // ignore secondary parsing error
-                }
-            }
-            throw new Error('Failed to parse AI response. See console for details.');
+    const data = await response.json();
+    const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (!text) {
+        console.error('Invalid response from Gemini API:', data);
+        throw new Error('Invalid response from Gemini API');
+    }
+    return text;
+}
+
+function parseAIResponse(responseText: string): any[] {
+    try {
+        const parsed = JSON.parse(responseText);
+        if (!Array.isArray(parsed)) {
+            throw new Error('AI response is not a JSON array.');
         }
+        return parsed;
+    } catch (error) {
+        console.error('Failed to parse AI JSON response:', error);
+        console.log('Raw AI response:', responseText);
+        const jsonMatch = responseText.match(/```json\n([\s\S]*?)\n```/);
+        if (jsonMatch) {
+            try {
+                return JSON.parse(jsonMatch[1]);
+            } catch {
+                /* ignore */
+            }
+        }
+        throw new Error('Failed to parse AI response. See console for details.');
     }
 }

--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -4,7 +4,7 @@
 // This file is the bridge between the browser UI and the headless AI engine.
 // It handles DOM interactions, user prompts, and orchestrates the AI workflow.
 
-import { AIEngine, GeminiEngine, AIAnnotationRequest } from './ai-engine.js';
+import { annotateWithGemini, AIAnnotationRequest } from './ai-engine.js';
 import { Annotation as SharedAnnotation, generateId } from './pdf-utils.js';
 
 // Use the shared Annotation type from the project
@@ -80,12 +80,10 @@ export async function runAIAssistedAnnotation(
         return null; // Could not prepare the request
     }
 
-    // 6. Instantiate the engine and run the annotation process.
-    const engine: AIEngine = new GeminiEngine(geminiApiKey);
-
+    // 6. Call the Gemini API to get annotations
     try {
-        console.log("Orchestrator: Calling AI engine for multi-page processing...");
-        const response = await engine.annotate(request);
+        console.log("Orchestrator: Calling Gemini API for multi-page processing...");
+        const response = await annotateWithGemini(geminiApiKey, request);
         console.log("Orchestrator: AI engine returned successfully.");
 
         // 7. Convert the engine's response into the application's annotation format.
@@ -189,7 +187,7 @@ async function getWordLevelOCR(canvas: HTMLCanvasElement, apiKey: string): Promi
 }
 
 /**
- * Prepares the request object needed by the AIEngine for multiple pages.
+ * Prepares the request object needed for the Gemini API for multiple pages.
  */
 async function prepareMultiPageAnnotationRequest(
     pageNumbers: number[],


### PR DESCRIPTION
## Summary
- remove the unused `AIEngine` interface and `GeminiEngine` class
- expose a simple `annotateWithGemini` function
- adjust orchestrator to call the new helper

## Testing
- `yarn build` *(fails: Request was cancelled)*
- `yarn test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687989bd3e8c8323bdc9ae51d0334cbb