### PR TITLE
Improve test wait logic

### DIFF
--- a/tests/chaya-basic.spec.ts
+++ b/tests/chaya-basic.spec.ts
@@ -18,7 +18,10 @@ test.describe('Chaya Basic Functionality', () => {
     await page.waitForSelector('#pdf-container canvas', { timeout: 15000 });
     
     // Wait a bit more for the loading to complete
-    await page.waitForTimeout(2000);
+    await page.waitForFunction(() => {
+      const loading = document.querySelector('#app-loading');
+      return loading && loading.classList.contains('hidden');
+    });
 
     // Verify PDF loaded successfully
     const canvases = page.locator('#pdf-container canvas');
@@ -131,7 +134,10 @@ test.describe('Chaya Basic Functionality', () => {
     await fileInput.setInputFiles(testPdfPath);
 
     await page.waitForSelector('#pdf-container canvas', { timeout: 15000 });
-    await page.waitForTimeout(2000);
+    await page.waitForFunction(() => {
+      const loading = document.querySelector('#app-loading');
+      return loading && loading.classList.contains('hidden');
+    });
 
     // Programmatically add an annotation to the app state
     await page.evaluate(() => {
@@ -174,7 +180,10 @@ test.describe('Chaya Basic Functionality', () => {
     await fileInput.setInputFiles(testPdfPath);
 
     await page.waitForSelector('#pdf-container canvas', { timeout: 15000 });
-    await page.waitForTimeout(2000);
+    await page.waitForFunction(() => {
+      const loading = document.querySelector('#app-loading');
+      return loading && loading.classList.contains('hidden');
+    });
 
     // Switch to Read tab
     await page.click('#read-tab-btn');

--- a/tests/chaya-functionality.spec.ts
+++ b/tests/chaya-functionality.spec.ts
@@ -170,7 +170,9 @@ test.describe('Chaya Functionality Tests', () => {
         await page.mouse.move(layerBox!.x + 400, layerBox!.y + 250);
         await page.mouse.up();
 
-        await page.waitForTimeout(1000); // Wait for second annotation to be created
+        await page.waitForFunction(() =>
+          document.querySelectorAll('.annotation-box').length >= 2
+        );
 
         // Save .chaya file
         const downloadPromise = page.waitForEvent('download');


### PR DESCRIPTION
## Summary
- replace arbitrary timeouts in tests
- wait for loading overlay to disappear
- wait for annotation count instead of a fixed delay

## Testing
- `yarn test` *(fails: missing Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881bf0546688323a2005036d16f6da5